### PR TITLE
First pass at POST endpoint for persisting a Journal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+journal-project-backend/journal-project-backend

--- a/journal-project-backend/database.go
+++ b/journal-project-backend/database.go
@@ -6,14 +6,15 @@ import (
 
 func (p *Entry) saveEntry() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return ioutil.WriteFile(filename, []byte(p.Body), 0600)
 }
 
 func loadEntry(title string) (*Entry, error) {
 	filename := title + ".txt"
 	body, err := ioutil.ReadFile(filename)
+	var stringBody = string(body)
 	if err != nil {
 		return nil, err
 	}
-	return &Entry{Title: title, Body: body}, nil
+	return &Entry{Title: title, Body: stringBody}, nil
 }

--- a/journal-project-backend/server.go
+++ b/journal-project-backend/server.go
@@ -1,27 +1,52 @@
 package main
 
+// TODO
+// Connect to actual database
+// Write basic unit tests
+// Create CI/CD process with Github actions and terraform
+
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"log"
 	"net/http"
 )
 
 type Entry struct {
 	Title string
-	Body  []byte
+	Body  string
 }
 
 func main() {
+	http.HandleFunc("/entries/", handleEntriesRequest)
 	http.HandleFunc("/entries/view/", viewEntry)
 	http.HandleFunc("/entries/edit/", editEntry)
 
-	p1 := &Entry{Title: "Hello", Body: []byte("This is a sample entry in a journal")}
-	p1.saveEntry()
-	p2, _ := loadEntry("Hello")
-	fmt.Println(string(p2.Body))
-
 	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func handleEntriesRequest(response http.ResponseWriter, request *http.Request) {
+	switch request.Method {
+	case "POST":
+		createEntry(response, request)
+	}
+}
+
+func createEntry(response http.ResponseWriter, request *http.Request) {
+	body, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		panic(err)
+	}
+	log.Println("Body received" + string(body))
+	var entry Entry
+	err = json.Unmarshal(body, &entry)
+	if err != nil {
+		panic(err)
+	}
+	log.Println("Entry received" + entry.Title)
+	entry.saveEntry()
 }
 
 func viewEntry(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adding an endpoint (localhost:8080/entries/) that you can make a POST request to to save a journal entry.  Currently this endpoint accepts JSON like so:
`{
	"Title": "My first journal",
	"Body": "This is the first entry!"
}`

Lot more to do, but this is a start